### PR TITLE
Drop env-specific Eclipse library specifiers

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/1.6.0"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="war/WEB-INF/lib/jscience.jar">
 		<attributes>
 			<attribute name="javadoc_location" value="file:/Users/ian/java-libs/jscience-4.3/api/"/>
@@ -17,6 +17,6 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
-	<classpathentry kind="con" path="com.google.appengine.eclipse.core.GAE_CONTAINER/App Engine (1)"/>
+	<classpathentry kind="con" path="com.google.appengine.eclipse.core.GAE_CONTAINER"/>
 	<classpathentry kind="output" path="war/WEB-INF/classes"/>
 </classpath>


### PR DESCRIPTION
Thanks for open-sourcing LastCalc!  I cleaned up the names of two of the libraries in the Eclipse config, since they were reliant on system-specific configurations.  They should now be portable between anybody's Eclipse installation.
